### PR TITLE
fix __construct(): Implicitly marking parameter $concord as nullable is deprecated

### DIFF
--- a/src/Proxies/BaseProxy.php
+++ b/src/Proxies/BaseProxy.php
@@ -30,7 +30,7 @@ abstract class BaseProxy
      *
      * @param Concord $concord
      */
-    public function __construct(Concord $concord = null)
+    public function __construct(?Concord $concord = null)
     {
         $this->concord = $concord ?: app('concord');
 


### PR DESCRIPTION
Please go through this checklist, it is mandatory to accept your PR

- [ ] Include the summary of your change.
- [ ] Make sure all the tests are passing
- [ ] Make sure StyleCI is passing
- [ ] In case you add new functionality, it must be covered by tests
